### PR TITLE
Prevent querying the DOM, if supported

### DIFF
--- a/multirange.js
+++ b/multirange.js
@@ -4,11 +4,11 @@ var supportsMultiple = self.HTMLInputElement && "valueLow" in HTMLInputElement.p
 
 var descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
 
-self.multirange = function(input) {
-	if (supportsMultiple) {
-		return;
-	}
+if (supportsMultiple) {
+	return;
+}
 
+self.multirange = function(input) {
 	var values = input.getAttribute("value").split(",");
 	var max = +input.max || 100;
 	var ghost = input.cloneNode();


### PR DESCRIPTION
If I'm reading the code right, you can return a little earlier and not touch the DOM and not have to run the `multirange` function.
