### PR TITLE
set local scope of document

### DIFF
--- a/multirange.js
+++ b/multirange.js
@@ -1,4 +1,4 @@
-(function() {
+(function(document) {
 "use strict";
 
 var supportsMultiple = self.HTMLInputElement && "valueLow" in HTMLInputElement.prototype;
@@ -76,4 +76,4 @@ else {
 	multirange.init();
 }
 
-})();
+})(document);


### PR DESCRIPTION
Caching the `document` locally will improve the performance and helps when minification is used.
