### PR TITLE
Allow 'max' of 0 and Check 'value' for absence and Update low/high on direct 'value' change.

### DIFF
--- a/multirange.js
+++ b/multirange.js
@@ -10,18 +10,10 @@ self.multirange = function(input) {
 		return;
 	}
 
-	var values = [];
-	if(input.hasAttribute("value")) {
-		values = input.getAttribute("value").split(",");
-	}
-	var min = 0;
-	var max = 100;
-	if(input.hasAttribute("min")) {
-		min = +input.min;
-	}
-	if(input.hasAttribute("max")) {
-		max = +input.max;
-	}
+	var value = input.getAttribute("value");
+	var values = value === null ? [] : value.split(",");
+	var min = +(input.min || 0);
+	var max = +(input.max || 100);
 	var ghost = input.cloneNode();
 
 	input.classList.add("multirange", "original");

--- a/multirange.js
+++ b/multirange.js
@@ -59,6 +59,7 @@ self.multirange = function(input) {
 				var values = v.split(",");
 				this.valueLow = values[0];
 				this.valueHigh = values[1];
+				update();
 			},
 			enumerable: true
 		});

--- a/multirange.js
+++ b/multirange.js
@@ -11,8 +11,14 @@ self.multirange = function(input) {
 	}
 
 	var values = input.getAttribute("value").split(",");
-	var min = +input.min || 0;
-	var max = +input.max || 100;
+	var min = 0;
+	var max = 100;
+	if(input.hasAttribute("min")) {
+		min = +input.min;
+	}
+	if(input.hasAttribute("max")) {
+		max = +input.max;
+	}
 	var ghost = input.cloneNode();
 
 	input.classList.add("multirange", "original");

--- a/multirange.js
+++ b/multirange.js
@@ -10,7 +10,10 @@ self.multirange = function(input) {
 		return;
 	}
 
-	var values = input.getAttribute("value").split(",");
+	var values = [];
+	if(input.hasAttribute("value")) {
+		values = input.getAttribute("value").split(",");
+	}
 	var min = 0;
 	var max = 100;
 	if(input.hasAttribute("min")) {


### PR DESCRIPTION
1) Until now having a range input with e.g. min=-10 and max=0 lead to unexpected behavior, as max=0 was interpreted as empty and replaced by 100.
2) Although an empty 'value' was already taken care of ("values[0] || ...")
3) While changing the value directly using JS was possible, the graphical representation did not update correctly (only on user interaction).