### PR TITLE
Don't crash if the oninput property is undefined

### DIFF
--- a/multirange.js
+++ b/multirange.js
@@ -57,7 +57,9 @@ self.multirange = function(input) {
 		});
 	}
 
-	ghost.oninput = input.oninput.bind(input);
+	if (typeof input.oninput === "function") {
+		ghost.oninput = input.oninput.bind(input);
+	}
 
 	function update() {
 		ghost.style.setProperty("--low", 100 * ((input.valueLow - min) / (max - min)) + 1 + "%");


### PR DESCRIPTION
If I open the webpage on a current chrome or firefox, only the first range slider is transformed. It crashes because the oninput property is not defined.

This should fix that.