### PR TITLE
An interface isn't usable as a function

### DIFF
--- a/multirange.d.ts
+++ b/multirange.d.ts
@@ -1,4 +1,7 @@
-export default interface multirange {
-	(element: HTMLInputElement): void;
-	init(): void;
+declare namespace multirange {
+	export function init(): void;
 }
+
+declare function multirange(element: HTMLInputElement): void;
+
+export default multirange;


### PR DESCRIPTION
Tiny followup on my typescript definition, I was exporting an interface which isn't usable as a function when importing in typescript :man_facepalming: 